### PR TITLE
Introduced some fixes for Python 3 compatibility

### DIFF
--- a/SPF2IP.py
+++ b/SPF2IP.py
@@ -29,14 +29,22 @@ def dns_request_unicode(hostname,record_type,*args,**kwargs):
         value = value.decode('utf-8')
       output.append(value)
     elif record_type == "MX":
-      value = entry.exchange
-      if type(value) is not unicode:
-        value = value.__str__().encode('utf-8').decode('utf-8')
+      try:
+        value = entry.exchange.decode('utf-8')
+      except AttributeError as err:
+        if err.args[0] == "'Name' object has no attribute 'decode'":
+          value = unicode(entry.exchange)
+        else:
+          raise
       output.append(value)
     elif record_type == "TXT":
-      value = ''.join([str(ent) for ent in entry.strings])
-      if type(value) is not unicode:
-        value = value.decode('utf-8')
+      value_array = []
+      for ent in entry.strings:
+        if type(ent) is not unicode:
+          value_array.append(ent.decode('utf-8'))
+        else:
+          value_array.append(ent)
+      value = ''.join(value_array)
       output.append(value)
   return output
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='SPF2IP',
-    version='1.0.4',
+    version='1.0.5',
 
     description='Python module to get IP addresses from an SPF record',
     long_description=long_description,

--- a/test_SPF2IP.py
+++ b/test_SPF2IP.py
@@ -125,11 +125,13 @@ dns_records = {
 class fakedns:
   def __init__(self,value,record_type):
     if record_type == 'TXT':
-      self.strings = value
+      self.strings = []
+      for entry in value:
+        self.strings.append(entry.encode('utf-8'))
     elif record_type == 'A' or record_type == 'AAAA':
-      self.address = value
+      self.address = value.encode('utf-8')
     elif record_type == 'MX':
-      self.exchange = value
+      self.exchange = value.encode('utf-8')
 def fake_dns_resolver(hostname,record_type):
   try:
     dns_records[hostname]


### PR DESCRIPTION
Seems like the dnspython package might have changed
the way in which it presents TXT objects in Python 3.
I didn't have a lot of time to look into it, but this
package really needs a whole refactor. Anyway, the
changes which I'm introducing here will resolve #2